### PR TITLE
device_configuration_checker.py: Fix serial recording

### DIFF
--- a/tools/device_configuration_checker.py
+++ b/tools/device_configuration_checker.py
@@ -247,6 +247,12 @@ def check(args):
 
     manager = DevicesManager(args)
     device = manager.reserve_specific(args.device)
+    if args.record:
+        if args.verbose:
+            print("Serial recording enabled on " + args.device)
+
+        device.parameters["serial_log_name"] = args.device + "_serial.log"
+        device.record_serial()
 
     if args.verbose:
         print("Device " + args.device + " acquired, running checks")


### PR DESCRIPTION
Add serial recording back to --check and --checkall which was removed
with previous patch.

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
