### PR TITLE
AFT: Fix some device checks hanging with --checkall

### DIFF
--- a/device.py
+++ b/device.py
@@ -22,7 +22,7 @@ import threading
 import abc
 
 from time import sleep
-from threading import current_thread
+import os
 from six import with_metaclass
 
 from aft.tools.thread_handler import Thread_handler as thread_handler
@@ -66,7 +66,7 @@ class Device(with_metaclass(abc.ABCMeta, object)):
                                 args=(self.parameters["serial_port"],
                                 self.parameters["serial_bauds"],
                                 self.parameters["serial_log_name"]),
-                                name=(current_thread().name + "recorder"))
+                                name=(str(os.getpid()) + "recorder"))
 
         recorder.start()
         thread_handler.add_thread(recorder)

--- a/logger.py
+++ b/logger.py
@@ -17,10 +17,10 @@ every machine gets its own [machine]_aft.log and [machine]_ssh.log instead
 of every machines logging to aft.log and ssh.log. When 'aft --checkall accurate'
 is used, logging messages will be written to same aft.log and ssh.log files.
 
-If new logger is needed, Logger.info/debug/warning... makes new
-one automatically when called with 'filename=' argument. Loggers are made thread
-specific. Using init_thread() function, prefix to threads filenames can be
-added/changed.
+If new logger is needed, Logger.info()/.debug()/.warning()... makes new
+one automatically when called with 'filename=' argument. Loggers are made
+process specific. Using init_process() function, prefix to processes filenames
+can be added/changed.
 '''
 
 import os
@@ -31,11 +31,11 @@ class Logger(object):
     '''
     Logger class for holding logging methods and variables
 
-    THREADS: Dictionary with threads filename prefixes
+    PROCESSES: Dictionary with processes filename prefixes
     LOGGING_LEVEL: Logging level threshold for new loggers
     '''
 
-    THREADS = {}
+    PROCESSES = {}
     LOGGING_LEVEL = logging.INFO
 
     @staticmethod
@@ -60,14 +60,14 @@ class Logger(object):
                             format='%(asctime)s - %(levelname)s - %(message)s')
 
     @staticmethod
-    def init_thread(log_prefix=""):
+    def init_process(log_prefix=""):
         '''
-        Add/change threads filename prefix to dictionary
+        Add/change process's filename prefix to dictionary
 
         Args:
             log_prefix: String for filename prefix
         '''
-        Logger.THREADS[str(os.getpid())] = log_prefix
+        Logger.PROCESSES[str(os.getpid())] = log_prefix
 
     @staticmethod
     def get_logger(filename):
@@ -117,8 +117,8 @@ class Logger(object):
     def _make(filename, file_mode="w"):
         '''
         Makes new logger. Logs name will be [prefix]+[filename]. Prefix will be
-        taken from THREADS dictionary. Adding threads prefix to dictionary
-        is done with init_thread('prefix=').
+        taken from PROCESSES dictionary. Adding PROCESS'S prefix to dictionary
+        is done with init_process('prefix=').
 
         Args:
             filename: String for filename suffix
@@ -128,13 +128,14 @@ class Logger(object):
         logger = logging.getLogger(str(os.getpid()) + filename)
         logger.setLevel(Logger.LOGGING_LEVEL)
 
-        # If thread_init() hasn't been used before making new logger, prefix
-        # will be threads name so every threads log filename will be different
-        if not str(os.getpid()) in Logger.THREADS:
-            Logger.THREADS[str(os.getpid())] = str(os.getpid())
-            print("Threads logger hasn't been initialized with thread_init.")
+        # If init_process() hasn't been used before making new logger, prefix
+        # will be process's name so every process's' log filename will be
+        # different
+        if not str(os.getpid()) in Logger.PROCESSES:
+            Logger.PROCESSES[str(os.getpid())] = str(os.getpid())
+            print("Process's logger hasn't been initialized with init_process.")
 
-        filename = Logger.THREADS[str(os.getpid())] + filename
+        filename = Logger.PROCESSES[str(os.getpid())] + filename
         handler = logging.FileHandler(filename, mode=file_mode)
         handler.setLevel(Logger.LOGGING_LEVEL)
         _format = ('%(asctime)s - %(levelname)s - %(message)s')

--- a/logger.py
+++ b/logger.py
@@ -23,8 +23,8 @@ specific. Using init_thread() function, prefix to threads filenames can be
 added/changed.
 '''
 
+import os
 import logging
-from threading import current_thread
 import aft.config as config
 
 class Logger(object):
@@ -67,7 +67,7 @@ class Logger(object):
         Args:
             log_prefix: String for filename prefix
         '''
-        Logger.THREADS[current_thread().name] = log_prefix
+        Logger.THREADS[str(os.getpid())] = log_prefix
 
     @staticmethod
     def get_logger(filename):
@@ -77,7 +77,7 @@ class Logger(object):
         Args:
             filename: String for filename/logger suffix, default is aft.log
         '''
-        logger = logging.getLogger(current_thread().name + filename)
+        logger = logging.getLogger(str(os.getpid()) + filename)
         if not logger.handlers:
             Logger._make(filename)
 
@@ -125,16 +125,16 @@ class Logger(object):
             file_mode: Logger handlers file mode, default 'w' = write
         '''
 
-        logger = logging.getLogger(current_thread().name + filename)
+        logger = logging.getLogger(str(os.getpid()) + filename)
         logger.setLevel(Logger.LOGGING_LEVEL)
 
         # If thread_init() hasn't been used before making new logger, prefix
         # will be threads name so every threads log filename will be different
-        if not current_thread().name in Logger.THREADS:
-            Logger.THREADS[current_thread().name] = current_thread().name
+        if not str(os.getpid()) in Logger.THREADS:
+            Logger.THREADS[str(os.getpid())] = str(os.getpid())
             print("Threads logger hasn't been initialized with thread_init.")
 
-        filename = Logger.THREADS[current_thread().name] + filename
+        filename = Logger.THREADS[str(os.getpid())] + filename
         handler = logging.FileHandler(filename, mode=file_mode)
         handler.setLevel(Logger.LOGGING_LEVEL)
         _format = ('%(asctime)s - %(levelname)s - %(message)s')

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def main(argv=None):
 
     try:
         logger.init_root_logger()
-        logger.init_thread()
+        logger.init_process()
 
         config.parse()
 

--- a/tools/device_configuration_checker.py
+++ b/tools/device_configuration_checker.py
@@ -236,7 +236,7 @@ def check(args):
         print("Running configuration check on " + args.device)
 
     if args.checkall:
-        logger.init_thread(args.device + "_")
+        logger.init_process(args.device + "_")
 
     # Initialize ssh.log so it logs to the right directory
     logger.info("Logger initialized for ssh", filename="ssh.log")
@@ -318,32 +318,14 @@ def _run_tests_on_know_good_image(args, device):
     try:
         working_dir = os.getcwd()
         os.chdir(os.path.join(image_directory_path, "iottest"))
-        # nuke test logs
-        for f in os.listdir("."):
-            if "ssh_target_log" in f:
-                os.remove(f)
 
         os.chdir(image_directory_path)
-        ## Remove all log and xml files from previous run to prevent clutter
-        #for f in os.listdir("."):
-        #    if f.endswith(".log") or f.endswith(".xml"):
-        #        os.remove(f)
-
 
         device.write_image(image)
 
         tester = Tester(device)
         tester.execute()
         results = (tester.get_results(), tester.get_results_str())
-
-        '''
-        #Move all ssh.log and serial.log files to the directory which started aft
-        files = os.listdir(os.getcwd())
-        for _file in files:
-            if "ssh.log" in _file or "serial.log" in _file:
-                os.rename(os.path.abspath(_file),
-                          os.path.join(working_dir, _file))
-        '''
 
         os.chdir(working_dir)
 


### PR DESCRIPTION
Device_configuration_check.py previously made a process inside a thread
for each device being checked which seemed to have some issues with it.
This patch removes the thread layer and every device only gets its own
process which also makes the code cleaner.

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
