### PR TITLE
AFT: Use separate working directories for health checks

### DIFF
--- a/tools/ansiparser.py
+++ b/tools/ansiparser.py
@@ -49,8 +49,8 @@ def parse_file(input_file_name):
           renamed to original_file after the original file has been backed up
 
     """
-    raw_input_file_name = "raw_" + input_file_name
-    temp_name = "temp_" + input_file_name
+    raw_input_file_name = input_file_name + ".raw"
+    temp_name = input_file_name + ".temp"
 
     with open(input_file_name, "rb") as input_file:
         with open(temp_name, "w") as output_file:

--- a/tools/setfattr_script.sh
+++ b/tools/setfattr_script.sh
@@ -11,7 +11,7 @@ ATTRIBUTE_NAME="security.ima"
 VALUE=$1
 FILE_PATH=$2
 
-# sanity checking the path. Check that the mount directory
+# sanity checking the path. Check that the file path seems valid
 if [[ "${FILE_PATH}" =~ ^\./mount_directory/home/root/\.ssh/authorized_keys$ ]]; then
     ${COMMAND} -n ${ATTRIBUTE_NAME} -v ${VALUE} ${FILE_PATH}
 else


### PR DESCRIPTION
Currently all devices with same type share a working directory. This can
cause various issues and in general makes the process unpredictable.
Create and populate a separate working directory instead.

Additionally, a bug with serial record log renaming was found during testing this (absoulute paths + prefixing file names do not mix well). This has been fixed as well.

A typo in a helper script was additionally found and fixed.

Signed-off-by: Erkka Kääriä erkka.kaaria@intel.com
