### PR TITLE
AFT: Move PEM calls inside a keyboard emulator class

### DIFF
--- a/default_config/devices/catalog.cfg
+++ b/default_config/devices/catalog.cfg
@@ -1,6 +1,7 @@
 [Gigabyte]
 platform = PC
 cutter_type = ClewareCutter
+keyboard_emulator = ArduinoKeyboard
 test_plan = iot_qatest
 target_device = /dev/sda
 root_partition = /dev/sda2
@@ -13,6 +14,7 @@ serial_bauds = 115200
 [GalileoV2]
 platform = PC
 cutter_type = ClewareCutter
+keyboard_emulator = ArduinoKeyboard
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
 root_partition = /dev/mmcblk0p2
@@ -25,6 +27,7 @@ serial_bauds = 115200
 [MinnowboardMAX]
 platform = PC
 cutter_type = ClewareCutter
+keyboard_emulator = ArduinoKeyboard
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
 root_partition = /dev/mmcblk0p2

--- a/devicefactory.py
+++ b/devicefactory.py
@@ -23,6 +23,7 @@ import aft.devices.virtualboxdevice
 import aft.cutters.clewarecutter
 import aft.cutters.usbrelay
 import aft.cutters.mockcutter
+import aft.kb_emulators.arduinokeyboard
 
 _DEVICE_CLASSES = {
     "beagleboneblack" : aft.devices.beagleboneblackdevice.BeagleBoneBlackDevice,
@@ -35,7 +36,20 @@ _CUTTER_CLASSES = {
     "usbrelay" : aft.cutters.usbrelay.Usbrelay,
     "mockcutter" : aft.cutters.mockcutter.Mockcutter
 }
+_KB_EMULATOR_CLASSES = {
+    "arduinokeyboard" : aft.kb_emulators.arduinokeyboard.ArduinoKeyboard,
+}
 
+def build_kb_emulator(config):
+    """
+    Construct a keyboard emulator instance of type config["keyboard_emulator"]
+    """
+    if "keyboard_emulator" in config.keys():
+        kb_emulator_class = _KB_EMULATOR_CLASSES[
+                                        config["keyboard_emulator"].lower()]
+        return kb_emulator_class(config)
+    else:
+        return None
 
 def build_cutter(config):
     """
@@ -44,9 +58,9 @@ def build_cutter(config):
     cutter_class = _CUTTER_CLASSES[config["cutter_type"].lower()]
     return cutter_class(config)
 
-def build_device(config, cutter):
+def build_device(config, cutter, kb_emulator=None):
     """
     Construct a device instance of type config["platform"]
     """
     device_class = _DEVICE_CLASSES[config["platform"].lower()]
-    return device_class(config, cutter)
+    return device_class(config, cutter, kb_emulator)

--- a/devices/beagleboneblackdevice.py
+++ b/devices/beagleboneblackdevice.py
@@ -132,13 +132,14 @@ class BeagleBoneBlackDevice(Device):
     _TEST_MODE_RETRY_ATTEMPTS = 4
 
 
-    def __init__(self, parameters, channel):
+    def __init__(self, parameters, channel, kb_emulator):
         """
         Constructor
 
         Args:
             parameters (Dictionary): Device configuration parameters
             channel (aft.Cutter): The power cutter object
+            kb_emulator (aft.kb_emulators.kb_emulator): Keyboard emulator object
 
         Returns:
             None
@@ -146,7 +147,8 @@ class BeagleBoneBlackDevice(Device):
 
         super(BeagleBoneBlackDevice, self).__init__(
             device_descriptor=parameters,
-            channel=channel)
+            channel=channel,
+            kb_emulator=kb_emulator)
 
 
 

--- a/devices/device.py
+++ b/devices/device.py
@@ -37,13 +37,14 @@ class Device(with_metaclass(abc.ABCMeta, object)):
 
     _POWER_CYCLE_DELAY = 10
 
-    def __init__(self, device_descriptor, channel):
+    def __init__(self, device_descriptor, channel, kb_emulator=None):
         self.name = device_descriptor["name"]
         self.model = device_descriptor["model"]
         self.dev_id = device_descriptor["id"]
         self.test_plan = device_descriptor["test_plan"]
         self.parameters = device_descriptor
         self.channel = channel
+        self.kb_emulator = kb_emulator
 
     @abc.abstractmethod
     def write_image(self, file_name):

--- a/devices/edisondevice.py
+++ b/devices/edisondevice.py
@@ -128,16 +128,18 @@ class EdisonDevice(Device):
     IFWI_DFU_FILE = "edison_ifwi-dbg"
     _NIC_FILESYSTEM_LOCATION = "/sys/class/net"
 
-    def __init__(self, parameters, channel):
+    def __init__(self, parameters, channel, kb_emulator):
         """
         Constructor
 
         Args:
             parameters (dictionary): Device configuration parameters
             channel (aft.Cutter): The power cutter object
+            kb_emulator (aft.kb_emulators.kb_emulator): Keyboard emulator object
         """
         super(EdisonDevice, self).__init__(device_descriptor=parameters,
-                                           channel=channel)
+                                           channel=channel,
+                                           kb_emulator=kb_emulator)
         self._configuration = parameters
 
         self._FLASHER_OUTPUT_LOG = "flash_" + self._configuration["name"] + ".log"

--- a/devices/virtualboxdevice.py
+++ b/devices/virtualboxdevice.py
@@ -66,7 +66,7 @@ class VirtualBoxDevice(Device):
     _MODULE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
     _HARNESS_AUTHORIZED_KEYS_FILE = "authorized_keys"
 
-    def __init__(self, parameters, channel):
+    def __init__(self, parameters, channel, kb_emulator):
         """
         Constructor
 
@@ -75,7 +75,8 @@ class VirtualBoxDevice(Device):
             channel (nil): Power cutter. Unused as the tests are run in a VM
         """
         super(VirtualBoxDevice, self).__init__(device_descriptor=parameters,
-                                               channel=channel)
+                                               channel=channel,
+                                               kb_emulator=kb_emulator)
         # virtual hard drive file name - used when mounting the hard drive
         self._vhdd = None
         # virtual machine name - used when interfacing with the machine through

--- a/devicesmanager.py
+++ b/devicesmanager.py
@@ -174,7 +174,11 @@ class DevicesManager(object):
         for device_config in self.device_configs:
             if device_config["model"].lower() == self._args.machine.lower():
                 cutter = devicefactory.build_cutter(device_config["settings"])
-                device = devicefactory.build_device(device_config["settings"], cutter)
+                kb_emulator = devicefactory.build_kb_emulator(
+                                                    device_config["settings"])
+                device = devicefactory.build_device(device_config["settings"],
+                                                    cutter,
+                                                    kb_emulator)
                 devices.append(device)
 
         devices = self._remove_blacklisted_devices(devices)
@@ -194,7 +198,11 @@ class DevicesManager(object):
         for device_config in self.device_configs:
             if device_config["name"].lower() == machine_name.lower():
                 cutter = devicefactory.build_cutter(device_config["settings"])
-                device = devicefactory.build_device(device_config["settings"], cutter)
+                kb_emulator = devicefactory.build_kb_emulator(
+                                                    device_config["settings"])
+                device = devicefactory.build_device(device_config["settings"],
+                                                    cutter,
+                                                    kb_emulator)
                 devices.append(device)
                 break
 

--- a/kb_emulators/__init__.py
+++ b/kb_emulators/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2016 Intel, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; version 2 of the License
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.

--- a/kb_emulators/arduinokeyboard.py
+++ b/kb_emulators/arduinokeyboard.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright (c) 2016 Intel, Inc.
+# Author Simo Kuusela <simo.kuus@intel.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+
+from multiprocessing import Process, Queue
+
+from aft.kb_emulators.kb_emulator import KeyboardEmulator
+import aft.errors as errors
+from aft.logger import Logger as logger
+
+class ArduinoKeyboard(KeyboardEmulator):
+    """
+    Class for Arduino keyboard emulator
+    """
+
+    _TIMEOUT = 60
+    _INTERFACE = "serialconnection"
+
+    def __init__(self, config):
+        super(ArduinoKeyboard, self).__init__()
+
+        logger.init_root_logger()
+
+        self.emulator_path = config["pem_port"]
+        self.interface = config["pem_interface"]
+
+    def send_keystrokes(self, _file, timeout=_TIMEOUT):
+        """
+        Method to send keystrokes from a file
+        """
+        self._send_PEM_keystrokes(_file, timeout=timeout)
+
+    def _send_PEM_keystrokes(self, _file, timeout, attempts=1):
+        """
+        Try to send keystrokes within the time limit
+
+        Args:
+            keystrokes (str): PEM keystroke file
+            attempts (integer): How many attempts will be made
+            timeout (integer): Timeout for a single attempt
+
+        Returns:
+            None
+
+        Raises:
+            aft.errors.AFTDeviceError if PEM connection times out
+
+        """
+        from pem.main import main as pem_main
+
+        def call_pem(exceptions):
+            try:
+                pem_main(
+                [
+                    "pem",
+                    "--interface", self.interface,
+                    "--port", self.emulator_path,
+                    "--playback", _file
+                ])
+            except Exception as err:
+                exceptions.put(err)
+
+        for i in range(attempts):
+            logger.info(
+                "Attempt " + str(i + 1) + " of " + str(attempts) + " to send " +
+                "keystrokes through PEM")
+
+            exception_queue = Queue()
+            process = Process(target=call_pem, args=(exception_queue,))
+            # ensure python process is closed in case main process dies but
+            # the subprocess is still waiting for timeout
+            process.daemon = True
+
+            process.start()
+            process.join(timeout)
+
+            if not exception_queue.empty():
+                raise exception_queue.get()
+
+            if process.is_alive():
+                process.terminate()
+            else:
+                return
+
+        raise errors.AFTDeviceError("Failed to connect to PEM")

--- a/kb_emulators/kb_emulator.py
+++ b/kb_emulators/kb_emulator.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright (c) 2016 Intel, Inc.
+# Author Simo Kuusela <simo.kuus@intel.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+
+"""
+Base class for keyboard emulators.
+"""
+
+import abc
+from six import with_metaclass
+
+class KeyboardEmulator(with_metaclass(abc.ABCMeta, object)):
+    """
+    Common abstract base class for keyboard emulators.
+    """
+    TIMEOUT = 60 # Timeout for sending
+
+    @abc.abstractmethod
+    def send_keystrokes(self, keystrokes, timeout=TIMEOUT):
+        """
+        Method to send keystrokes
+        """

--- a/main.py
+++ b/main.py
@@ -40,7 +40,6 @@ def main(argv=None):
     """
 
     try:
-        logger.init_root_logger()
         logger.init_process()
 
         config.parse()

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     packages = ["aft"],
     package_dir = {"aft" : "."},
     package_data = {"aft" : ["cutters/*.py",
+                             "kb_emulators/*.py",
                              "devices/*.py", "devices/data/*",
                              "testcases/*.py",
                              "tools/*.py",

--- a/tools/edison_recovery_flasher.py
+++ b/tools/edison_recovery_flasher.py
@@ -208,7 +208,7 @@ def _get_blacklisted_edison_devices(device_manager, blacklisted_edison_names):
                 cutter = devicefactory.build_cutter(conf["settings"])
                 device = devicefactory.build_device(
                     conf["settings"],
-                    cutter)
+                    cutter, None)
                 blacklisted_edisons.append(device)
 
     return blacklisted_edisons

--- a/tools/topology_builder.py
+++ b/tools/topology_builder.py
@@ -55,7 +55,6 @@ import aft.tools.ssh as ssh
 from aft.logger import Logger as logger
 from aft.cutters.clewarecutter import ClewareCutter
 from aft.cutters.usbrelay import Usbrelay
-from pem.main import main as pem_main
 from aft.tools.misc import local_execute
 from aft.devices.edisondevice import EdisonDevice
 
@@ -409,7 +408,7 @@ class TopologyBuilder(object):
 
             args["edison_usb_port"] = usb_port
 
-            dev = EdisonDevice(args, None)
+            dev = EdisonDevice(args, None, None)
             dev.open_interface()
 
             # we do something slightly different here when compared to the
@@ -548,7 +547,7 @@ class TopologyBuilder(object):
             None
 
         """
-
+        from pem.main import main as pem_main
         # give devices some time to boot\shutdown (mostly shutdown)
         #
         # failure to wait can lead to false positives, eg. port was incorrectly


### PR DESCRIPTION
Remove hard coded pem calls and move pem inside Arduinokeyboard class.
Also a base class for keyboard emulators has been made. This makes adding
different keyboard emulators and hardware easier.

If AFT is updated to this version, new config setting has to be set
for devices in /etc/aft/devices/*.cfg files: keyboard_emulator = ArduinoKeyboard.

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
