### PR TITLE
AFT: Add ability to boot device to specified mode

### DIFF
--- a/devicesmanager.py
+++ b/devicesmanager.py
@@ -375,6 +375,27 @@ class DevicesManager(object):
                         print("Flashing failed, trying again " +
                             str(flash_retries - flash_attempt) + " more times")
 
+    def boot_device_to_mode(self, device, args):
+        '''
+        Boot specified device to mode specified by args.boot
+        '''
+        if device.__class__.__name__ == "EdisonDevice":
+            device._power_cycle()
+
+        if device.__class__.__name__ == "BeagleBoneBlackDevice":
+            if args.boot == "test_mode":
+                device._enter_test_mode()
+            if args.boot == "service_mode":
+                device._enter_service_mode()
+
+        if device.__class__.__name__ == "PCDevice":
+            if args.boot == "test_mode":
+                device._enter_mode(device._test_mode)
+            if args.boot == "service_mode":
+                device._enter_mode(device._service_mode)
+
+        print("Succesfully booted to specified mode")
+
     def get_configs(self):
         return self.device_configs
 

--- a/main.py
+++ b/main.py
@@ -125,6 +125,9 @@ def main(argv=None):
         if not args.nopoweroff:
             device.detach()
 
+        if args.boot:
+            device_manager.boot_device_to_mode(device, args)
+
         device_manager.release(device)
 
         if "backup_argv" in locals():
@@ -175,8 +178,7 @@ def parse_args():
         action="store",
         nargs="?",
         help = "Image to write: a local file, compatible with the selected " +
-        "machine."
-        )
+        "machine.")
 
     parser.add_argument(
         "--device",
@@ -200,7 +202,7 @@ def parse_args():
         nargs="?",
         action="store",
         default="2",
-        help="Specify how many time flashing one machine will be tried.")
+        help="Specify how many times flashing one machine will be tried.")
 
     parser.add_argument(
         "--record",
@@ -226,6 +228,14 @@ def parse_args():
         action="store_true",
         default=False,
         help="Do not power off the DUT after testing")
+
+    parser.add_argument(
+        "--boot",
+        type=str,
+        nargs="?",
+        action="store",
+        choices=["test_mode", "service_mode"],
+        help="Boot device to specific mode")
 
     parser.add_argument(
         "--check",


### PR DESCRIPTION
Allow booting device to specified mode with '--boot=[mode]' argument. So
for example booting testable image with specific minnowboard looks
something like:
'aft minnowboard --device=minnowboard_1 --noflash --notest --boot=test_mode'

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
