### PR TITLE
server: Install default config file and folders

### DIFF
--- a/server/default_config/devices.cfg
+++ b/server/default_config/devices.cfg
@@ -1,0 +1,9 @@
+[Minnowboard1]
+bb_ip = 192.168.30.1
+dut = Minnowboard
+workspace = /root/workspace/minnowboard/
+
+[Joule1]
+bb_ip = 192.168.30.2
+dut = Joule
+workspace = /root/workspace/bxtc/

--- a/server/setup.py
+++ b/server/setup.py
@@ -14,7 +14,13 @@
 """
 DAFT installation module
 """
+import os
 from setuptools import setup
+
+if os.path.isfile("/etc/daft/devices.cfg"):
+    DEFAULT_CONFIG = []
+else:
+    DEFAULT_CONFIG = ["default_config/devices.cfg"]
 
 setup(
     name = "DAFT",
@@ -25,4 +31,6 @@ setup(
     url = "github",
     py_modules = ["main"],
     entry_points = { "console_scripts" : ["daft=main:main"] },
+    data_files = [("/etc/daft/", DEFAULT_CONFIG),
+                  ("/etc/daft/lockfiles/", [])]
     )


### PR DESCRIPTION
When installing DAFT create folders and create configuration
file.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>