### PR TITLE
DAFT: Boot BBB from nfs

### DIFF
--- a/client/default_config/aft.cfg
+++ b/client/default_config/aft.cfg
@@ -2,4 +2,4 @@
 lock_file = /var/lock/
 serial_log_name = serial.log
 aft_log_name = aft.log
-nfs_folder = /root
+nfs_folder = /root/workspace

--- a/client/devices/pcdevice.py
+++ b/client/devices/pcdevice.py
@@ -406,26 +406,6 @@ class PCDevice(Device):
                     ".ssh/authorized_keys")
             ])
 
-        if not self._uses_hddimg:
-            logger.info("Adding IMA attribute to the ssh-key")
-            ssh.remote_execute(
-                self.dev_ip,
-                [
-                    "setfattr",
-                    "-n",
-                    "security.ima",
-                    "-v",
-                    "0x01`sha1sum " +
-                    os.path.join(
-                        self._ROOT_PARTITION_MOUNT_POINT,
-                        root_user_home,
-                        ".ssh/authorized_keys") + " | cut '-d ' -f1`",
-                    os.path.join(
-                        self._ROOT_PARTITION_MOUNT_POINT,
-                        root_user_home,
-                        ".ssh/authorized_keys")
-                ])
-
         logger.info("Flushing.")
         ssh.remote_execute(self.dev_ip, ["sync"])
         logger.info("Unmounting.")

--- a/client/tools/ansiparser.py
+++ b/client/tools/ansiparser.py
@@ -54,7 +54,7 @@ def parse_file(input_file_name):
 
 
     # back up the file, just in case
-    print("Backing up " + input_file_name + " as " + raw_input_file_name + ".")
+    print("Backing up " + input_file_name + " as " + raw_input_file_name + ".", end="")
     os.rename(input_file_name, raw_input_file_name)
 
     # And rename the temp output file

--- a/server/default_config/daft.cfg
+++ b/server/default_config/daft.cfg
@@ -1,0 +1,3 @@
+[daft]
+workspace_nfs_path = /home/tester/
+bbb_fs_path = /daft/bbb_fs/

--- a/server/default_config/devices.cfg
+++ b/server/default_config/devices.cfg
@@ -1,9 +1,5 @@
 [Minnowboard1]
-bb_ip = 192.168.30.1
-dut = Minnowboard
-workspace = /root/workspace/minnowboard/
+bb_ip = 192.168.30.2
 
 [Joule1]
-bb_ip = 192.168.30.2
-dut = Joule
-workspace = /root/workspace/bxtc/
+bb_ip = 192.168.30.3

--- a/server/setup.py
+++ b/server/setup.py
@@ -17,14 +17,15 @@ DAFT installation module
 import os
 from setuptools import setup
 
-if os.path.isfile("/etc/daft/devices.cfg"):
-    DEFAULT_CONFIG = []
-else:
-    DEFAULT_CONFIG = ["default_config/devices.cfg"]
+DEFAULT_CONFIG = []
+if not os.path.isfile("/etc/daft/devices.cfg"):
+    DEFAULT_CONFIG.append("default_config/devices.cfg")
+if not os.path.isfile("/etc/daft/daft.cfg"):
+    DEFAULT_CONFIG.append("default_config/daft.cfg")
 
 setup(
     name = "DAFT",
-    version = "0.4",
+    version = "0.5",
     description = "Distributed Automatic Flasher Tester",
     author = "Simo Kuusela, Topi Kuutela, Igor Stoppa",
     author_email = "simo.kuusela@intel.com",


### PR DESCRIPTION
Changing testing setup so that BBB will boot from nfs. It will also
forward network traffic from DUT to the server so that copying the image
file isn't needed as the support image can mount the servers nfs folder
containing the image. Updating AFT on the Beaglebone is now done by
just copying the .py files to the BBB nfs folder. Added new daft.cfg
file for configuring DAFT behavior. Removed few useless options from
devices.cfg so only BBB ip address is needed. Don't add IMA-attribute to
the ssh-key as it is not needed anymore with refkit.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>