### PR TITLE
testing_harness/default_config/devices/: Add new devices

### DIFF
--- a/testing_harness/default_config/devices/catalog.cfg
+++ b/testing_harness/default_config/devices/catalog.cfg
@@ -2,8 +2,7 @@
 platform = PC
 test_plan = iot_qatest
 target_device = /dev/sda
-root_partition = /dev/sda2
-service_mode = ostro-ci
+service_mode = ubuntu
 test_mode = yocto
 service_mode_keystrokes = /root/kbsequences/gigabyte/boot_usb
 test_mode_keystrokes = /root/kbsequences/gigabyte/boot_internal
@@ -12,7 +11,6 @@ test_mode_keystrokes = /root/kbsequences/gigabyte/boot_internal
 platform = PC
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
-root_partition = /dev/mmcblk0p2
 service_mode = ci-test-image
 test_mode = yocto
 service_mode_keystrokes = /root/kbsequences/galileo/boot_second_option
@@ -24,11 +22,20 @@ platform = PC
 serial_port = /dev/ttyUSB0
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
-root_partition = /dev/mmcblk0p2
-service_mode = ostro-ci
+service_mode = ubuntu
 test_mode = yocto
 service_mode_keystrokes = /root/kbsequences/minnowboard/boot_usb
 test_mode_keystrokes = /root/kbsequences/empty
+
+[Minnowboard]
+platform = PC
+test_plan = iot_qatest
+target_device = /dev/mmcblk0
+service_mode = ubuntu
+test_mode = yocto
+service_mode_keystrokes = /root/kbsequences/minnowboard/boot_usb
+test_mode_keystrokes = /root/kbsequences/empty
+serial_port = /dev/ttyUSB0
 
 [Edison]
 platform = Edison
@@ -61,8 +68,17 @@ serial_port = /dev/ttyUSB0
 platform = PC
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
-root_partition = /dev/mmcblk0p2
-service_mode = ostro-ci
+service_mode = ubuntu
+test_mode = yocto
+service_mode_keystrokes = /root/kbsequences/joule/boot_usb
+test_mode_keystrokes = /root/kbsequences/empty
+serial_port = /dev/ttyUSB0
+
+[Joule]
+platform = PC
+test_plan = iot_qatest
+target_device = /dev/mmcblk0
+service_mode = ubuntu
 test_mode = yocto
 service_mode_keystrokes = /root/kbsequences/joule/boot_usb
 test_mode_keystrokes = /root/kbsequences/empty

--- a/testing_harness/default_config/devices/topology.cfg
+++ b/testing_harness/default_config/devices/topology.cfg
@@ -9,8 +9,11 @@ serial_port = /dev/ttyUSB0
 [GALILEO1]
 model = GalileoV2
 
-[MINNOWBOARD1]
+[MINNOWBOARDMAX1]
 model = MinnowboardMAX
+
+[MINNOWBOARD1]
+model = Minnowboard
 
 [GIGABYTE1]
 model = Gigabyte
@@ -20,3 +23,6 @@ model = BeagleBoneBlack
 
 [Bxtc1]
 model = Bxtc
+
+[Joule1]
+model = Joule


### PR DESCRIPTION
Add Joule and Minnowboard to default config. Also remove
'root_partition' options from PC devices default config as it isn't used anymore.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>