### PR TITLE
pc_host/main.py: Stop AFT if DAFT is stopped

### DIFF
--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -42,6 +42,9 @@ def main():
         print("Keyboard interrupt, stopping DAFT run")
         if beaglebone_dut:
             release_device(beaglebone_dut)
+            output = remote_execute(beaglebone_dut["bb_ip"],
+                                    ("killall -s SIGINT aft").split(),
+                                    timeout=10, config = config)
         return 0
 
     except ImageNameError:


### PR DESCRIPTION
Use 'killall -s SIGINT aft' to stop AFT on the testing harness if DAFT
has been stopped manually. Previously if DAFT was stopped with ctrl+c
AFT kept running on the testing harness.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>