### PR TITLE
Don't print empty lines when DAFT is run

### DIFF
--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -174,7 +174,7 @@ def execute_flashing(bb_dut, args, config):
             if os.path.isfile(log):
                 os.rename(log, "flash_" + log)
 
-    print(output)
+    print(output, end="")
     print("Flashing took: " + time_used(start_time))
 
 def execute_testing(bb_dut, args, config):
@@ -201,7 +201,7 @@ def execute_testing(bb_dut, args, config):
             if os.path.isfile(log):
                 os.rename(log, "test_" + log)
 
-    print(output)
+    print(output, end="")
     print("Testing took: " + time_used(start_time))
 
 def remote_execute(remote_ip, command, timeout = 60, ignore_return_codes = None,

--- a/testing_harness/tools/ansiparser.py
+++ b/testing_harness/tools/ansiparser.py
@@ -54,7 +54,7 @@ def parse_file(input_file_name):
 
 
     # back up the file, just in case
-    print("Backing up " + input_file_name + " as " + raw_input_file_name + ".", end="")
+    print("Backing up " + input_file_name + " as " + raw_input_file_name + ".")
     os.rename(input_file_name, raw_input_file_name)
 
     # And rename the temp output file


### PR DESCRIPTION
Previously if DAFT was ran without '--record' argument, it printed
something like:
Reserved Minnowboardmax1
Executing flashing of DUT
Flashing minnowboard1, attempt 1 of 2.
Flashing successful.

Flashing took: 3min 5s
Executing testing of the DUT
Testing minnowboard1.

Testing took: 1min 51s
Released Minnowboardmax1
DAFT run duration: 4min 57s

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>