### PR TITLE
Make initialize_testing_harness systemd service

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -443,7 +443,9 @@ git clone https://github.com/01org/DAFT.git
 cd DAFT/testing_harness
 python3 setup.py install
 cd
-cp DAFT/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.sh ~/
+cp DAFT/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.sh /usr/bin/
+cp DAFT/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.service /etc/systemd/system/
+ln -s /etc/systemd/system/initialize_testing_harness.service  /etc/systemd/system/multi-user.target.wants/
 cp DAFT/testing_harness_image_extras/watchdog/watchdog.py /usr/bin/watchdog
 cp DAFT/testing_harness_image_extras/watchdog/watchdog.service /etc/systemd/system/
 cp -r DAFT/testing_harness_image_extras/kbsequences /root/
@@ -456,8 +458,6 @@ iptables -t nat -A POSTROUTING --out-interface eth0 -j MASQUERADE
 iptables -A FORWARD --in-interface usb0 -j ACCEPT
 iptables-save > /etc/iptables.rules
 cp -r /var/ /_var
-vim /etc/rc.local
-    /root/initialize_testing_harness.sh # Add this line to the file before 'exit 0'
 vim /etc/sysctl.conf
     net.ipv4.ip_forward = 1 # Add this line to the file
 vim /etc/network/interfaces

--- a/testing_harness_image_extras/initialize_testing_harness/README.MD
+++ b/testing_harness_image_extras/initialize_testing_harness/README.MD
@@ -1,1 +1,1 @@
-This script will be called on the testing harness image /etc/rc.local that will run at start up.
+The initialize_testing_harness.sh script is used on the testing harness to set up USB gadget emulation, GPIO pins and system so it's ready to run AFT. The script file should be placed to /usr/bin/. The service file should be placed to /etc/systemd/system/ and to enable it make a symlink to it in /etc/systemd/system/multi-user.target.wants/.

--- a/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.service
+++ b/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Initialize testing harness
+ConditionFileIsExecutable=/usr/bin/initialize_testing_harness.sh
+After=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/initialize_testing_harness.sh
+RemainAfterExit=yes

--- a/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.sh
+++ b/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright (c) 2016 Intel, Inc.
 # Author Simo Kuusela <simo.kuusela@intel.com>
 #
@@ -10,7 +12,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 
-#!/bin/bash
 
 set_up_overlay() {
   mkdir /ramdisk/upper
@@ -106,4 +107,3 @@ set_up_gadget
 set_up_usb_network
 set_up_gpio
 set_up_system
-


### PR DESCRIPTION
Running the script with /etc/rc.local will cause some problems with
keyboard emulation. So make a systemd service that will run it.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>