### PR TITLE
pc_host/main.py: Allow numbers in DUT names

### DIFF
--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -134,7 +134,7 @@ def get_bbb_config():
     for device in config.sections():
         device_config = dict(config.items(device))
         device_config["lockfile"] = device
-        device_config["dut"] = ''.join(x for x in device if not x.isdigit())
+        device_config["dut"] = device.rstrip('1234567890_')
         configurations.append(device_config)
     return configurations
 


### PR DESCRIPTION
The line that is changed gets a device name from /etc/daft/devices.cfg
sections eg. [Minnowboard1] and removes all the numbers from the name.
Change it that it only removes numbers from the end of the name and also
removes underscores. This way a name like [Joule_570x_1] can be used.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>