### PR TITLE
Improve 'dut' argument and add new ones to DAFT CLI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -422,7 +422,7 @@ Flash and test an image while recording serial output:
 daft minnowboard yocto-image.dsk --record
 ```
 
-If flashing or entering test mode fails DAFT will blacklist the BBB used by locking the device until `/etc/daft/lockfiles/<device>` is emptied or removed. Also be aware that BBB has a watchdog that checks periodically if it has connection to the _192.168.30.1_ server and also if sshd and dnsmasq services are running. If it doesn't it will automatically reboot BBB. Removing the watchdog can be done by:
+For more info about using DAFT and its settings check [DAFT and AFT settings and commandline interface](#4-daft-and-aft-settings-and-commandline-interface) section. If flashing or entering test mode fails DAFT will blacklist the BBB used by locking the device until `/etc/daft/lockfiles/<device>` is emptied or removed. Also be aware that BBB has a watchdog that checks periodically if it has connection to the _192.168.30.1_ server and also if sshd and dnsmasq services are running. If it doesn't it will automatically reboot BBB. Removing the watchdog can be done by:
 ```
 rm /daft/bbb_fs/etc/systemd/system/multi-user.target.wants/watchdog.service
 ```
@@ -582,6 +582,9 @@ DAFT commandline interface options:
 * **image_file**: Image file to flash to the DUT.
 * **--record**: Record serial output from DUT.
 * **--update**: Update AFT on the BBB filesystem and DAFT on the PC. This should be ran while being on the root DAFT repository directory and with root permission.
+* **--noflash**: Skip flashing of DUT.
+* **--notest**: Skip testing of DUT.
+* **--noblacklisting**: If flashing or testing fails don't blacklist the device.
 
 ### 4.3 AFT settings
 AFT settings are located in `/etc/daft/daft.cfg` and on default are:

--- a/README.MD
+++ b/README.MD
@@ -578,7 +578,7 @@ Basic DAFT command:
 daft <dut> <image_file>
 ```
 DAFT commandline interface options:
-* **dut**: Type of DUT to flash. Should be one from the `/etc/daft/devices.cfg`.
+* **dut**: Type of DUT or sepcific DUT to flash. Should be one from the `/etc/daft/devices.cfg`.
 * **image_file**: Image file to flash to the DUT.
 * **--record**: Record serial output from DUT.
 * **--update**: Update AFT on the BBB filesystem and DAFT on the PC. This should be ran while being on the root DAFT repository directory and with root permission.

--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -55,11 +55,14 @@ def main():
 
     except:
         if beaglebone_dut:
-            lockfile = "/etc/daft/lockfiles/" + beaglebone_dut["lockfile"]
-            with open(lockfile, "a") as f:
-                f.write("Blacklisted because flashing/testing failed\n")
-                print("FLashing/testing failed, blacklisted " +
-                      beaglebone_dut["lockfile"])
+            if args.noblacklisting:
+                release_device(beaglebone_dut)
+            else:
+                lockfile = "/etc/daft/lockfiles/" + beaglebone_dut["lockfile"]
+                with open(lockfile, "a") as f:
+                    f.write("Blacklisted because flashing/testing failed\n")
+                    print("FLashing/testing failed, blacklisted " +
+                          beaglebone_dut["lockfile"])
         raise
 
 def update(config):
@@ -313,6 +316,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Skip device testing")
+
+    parser.add_argument(
+        "--noblacklisting",
+        action="store_true",
+        default=False,
+        help="Don't blacklist device if flashing/testing fails")
 
     parser.add_argument(
         "--update",

--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -32,7 +32,8 @@ def main():
     try:
         start_time = time.time()
         beaglebone_dut = reserve_device(args)
-        execute_flashing(beaglebone_dut, args, config)
+        if not args.noflash:
+            execute_flashing(beaglebone_dut, args, config)
         execute_testing(beaglebone_dut, args, config)
         release_device(beaglebone_dut)
         print("DAFT run duration: " + time_used(start_time))
@@ -203,7 +204,7 @@ def execute_testing(bb_dut, args, config):
     try:
         output = remote_execute(bb_dut["bb_ip"],
                                 ["cd", "/root/workspace" + current_dir,";aft",
-                                dut, args.image_file, record, "--noflash"],
+                                dut, record, "--noflash"],
                                 timeout=1200, config = config)
 
     finally:
@@ -299,6 +300,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Record serial output from DUT while flashing/testing")
+
+    parser.add_argument(
+        "--noflash",
+        action="store_true",
+        default=False,
+        help="Skip device flashing")
 
     parser.add_argument(
         "--update",

--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -34,7 +34,8 @@ def main():
         beaglebone_dut = reserve_device(args)
         if not args.noflash:
             execute_flashing(beaglebone_dut, args, config)
-        execute_testing(beaglebone_dut, args, config)
+        if not args.notest:
+            execute_testing(beaglebone_dut, args, config)
         release_device(beaglebone_dut)
         print("DAFT run duration: " + time_used(start_time))
         return 0
@@ -306,6 +307,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Skip device flashing")
+
+    parser.add_argument(
+        "--notest",
+        action="store_true",
+        default=False,
+        help="Skip device testing")
 
     parser.add_argument(
         "--update",


### PR DESCRIPTION
 Add possible arguments to skip flashing, skip testing and disable blacklisting for a run. Also improve 'dut' argument to allow using specific device.