### PR TITLE
Add argument to allow using different test plan

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -667,6 +667,9 @@ DAFT commandline interface options:
 * **--emulateusb**: Use testing harness USB emulation to boot the image instead
   of flashing it. You can use _--notest_ to only boot the image without running
   automatic tests.
+* **--testplan**: Specify a test plan to use from bbb_fs/etc/aft/test_plan/.
+  Use the test plan name without .cfg extension. On default the test plan for
+  the device in AFT device settings is used.
 
 ### 3.3 AFT settings
 
@@ -735,14 +738,18 @@ AFT commandline interface options:
   of flashing it. You can use _--notest_ to only boot the image without running
   automatic tests.
 * **--record**: Record serial output from DUT.
-* **--flash_retries**: Change how many times flashing will be tried. On default 2.
-* **--noflash**: Skip flashing image to the device eg. 'aft joule --noflash' would
-  run only tests.
+* **--flash_retries**: Change how many times flashing will be tried.
+  On default 2.
+* **--noflash**: Skip flashing image to the device eg. 'aft joule --noflash'
+  would run only tests.
 * **--notest**: Skip testing image.
 * **--nopoweroff**: After aft run, don't turn off device.
 * **--boot**: Boot device to specific mode. Options are 'service_mode' and
   'test_mode'. For example: 'aft joule --noflash --notest --boot=test_mode'
   would boot device to the flashed image.
+* **--testplan**: Specify a test plan to use from bbb_fs/etc/aft/test_plan/.
+    Use the test plan name without .cfg extension. On default the test plan for
+    the device in AFT device settings is used.
 * **--verbose**: Increase aft run verbosity.
 * **--debug**: Change aft logging level to 'debug'.
 

--- a/README.MD
+++ b/README.MD
@@ -694,12 +694,12 @@ the highest level configuration file. It is intended to store settings which are
 shared between all high-level device-types,ie. PC-devices or gadget-devices. The
 catalog.cfg is the configuration file describing each device type. Settings on
 these files:
-* **leases_file_name**: Path to the dnsmasq.leases file that contains IP addresses
-  of connected devices.
+* **leases_file_name**: Path to the dnsmasq.leases file that contains IP
+  addresses of connected devices.
 * **keyboard_emulator**: Keyboard emulator type. On default GadgetKeyboard which
   is the BBB keyboard emulation.
-* **cutter_type**: DUT power supply cutter/relay type. On default GpioCutter which
-  is a relay controlled with BBB GPIO pins.
+* **cutter_type**: DUT power supply cutter/relay type. On default GpioCutter
+  which is a relay controlled with BBB GPIO pins.
 * **gpio_pin**: GPIO pin that controls the cutter/relay if using GpioCutter.
 * **gpio_cutter_on**: GPIO pin value when relay should be closed. On default 1.
 * **gpio_cutter_off**: GPIO pin value when relay should be open. On default 0.
@@ -715,7 +715,8 @@ these files:
   to be tested.
 * **boot_usb_keystrokes**: Path to the keystrokes which boot DUT to service
   mode.
-* **boot_internal_keystrokes**: Path to the keystrokes which boot DUT to test mode.
+* **boot_internal_keystrokes**: Path to the keystrokes which boot DUT to test
+  mode.
 * **platform**: On catalog.cfg file option to inherit settings from specific
   platform.
 

--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -264,12 +264,15 @@ def execute_testing(bb_dut, args, config):
     dut = bb_dut["device_type"].lower()
     current_dir = os.getcwd().replace(config["workspace_nfs_path"], "")
     record = ""
+    testplan = ""
     if args.record:
         record = "--record"
+    if args.testplan:
+        testplan = "--testplan=" + args.testplan
     try:
         output = remote_execute(bb_dut["bb_ip"],
                                 ["cd", "/root/workspace" + current_dir,";aft",
-                                dut, record, "--noflash"],
+                                dut, record, testplan, "--noflash"],
                                 timeout=1200, config = config)
 
     finally:
@@ -393,6 +396,16 @@ def parse_args():
         action="store_true",
         default=False,
         help="Use the image in USB mass storage emulation instead of flashing")
+
+    parser.add_argument(
+        "--testplan",
+        type=str,
+        nargs="?",
+        action="store",
+        default="",
+        help="Specify a test plan to use from bbb_fs/etc/aft/test_plan/. Use " +
+             "the test plan name without .cfg extension. On default the test " +
+             "plan for the device in AFT device settings is used.")
 
     parser.add_argument(
         "--noblacklisting",

--- a/testing_harness/devicesmanager.py
+++ b/testing_harness/devicesmanager.py
@@ -235,6 +235,8 @@ class DevicesManager(object):
             device, tester: Reserved machine and tester handles.
         '''
         device = self.reserve_specific(args.device, model=args.machine)
+        if args.testplan:
+            device.test_plan = args.testplan
         tester = Tester(device)
 
         if args.record:
@@ -265,6 +267,8 @@ class DevicesManager(object):
             device, tester: Reserved machine and tester handles.
         '''
         device = self.reserve()
+        if args.testplan:
+            device.test_plan = args.testplan
         tester = Tester(device)
 
         if args.record:

--- a/testing_harness/main.py
+++ b/testing_harness/main.py
@@ -100,12 +100,6 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--catalog",
-        action="store",
-        help="Configuration file describing the supported device types",
-        default="/etc/aft/devices/catalog.cfg")
-
-    parser.add_argument(
         "machine",
         action="store",
         nargs="?",
@@ -172,6 +166,22 @@ def parse_args():
         action="store",
         choices=["test_mode", "service_mode"],
         help="Boot device to specific mode")
+
+    parser.add_argument(
+        "--catalog",
+        action="store",
+        help="Configuration file describing the supported device types",
+        default="/etc/aft/devices/catalog.cfg")
+
+    parser.add_argument(
+        "--testplan",
+        type=str,
+        nargs="?",
+        action="store",
+        default="",
+        help="Specify a test plan to use from /etc/aft/test_plan/. Use the " +
+             "test plan name without .cfg extension. On default the test " +
+             "plan for the device in AFT device settings is used.")
 
     parser.add_argument(
         "--verbose",


### PR DESCRIPTION
Currently the test plan used is always taken from AFT device settings
files. Add an argument to allow using different one than in the
settings. Of course currently you can change the settings but that isn't
really user friendly to do if different test runs want to use different
test plan. Also fex few too long lines in README.