### PR TITLE
testing_harness: Remove default root partition argument

### DIFF
--- a/testing_harness/devices/pcdevice.py
+++ b/testing_harness/devices/pcdevice.py
@@ -73,7 +73,6 @@ class PCDevice(Device):
                                        kb_emulator=kb_emulator)
 
         self._leases_file_name = parameters["leases_file_name"]
-        self.default_root_patition = parameters["root_partition"]
         self._service_mode_name = parameters["service_mode"]
         self._test_mode_name = parameters["test_mode"]
         self._test_mode = {


### PR DESCRIPTION
The root partition argument isn't used anymore, so it can be removed.

Signed-off-by: Christian da Costa <christian.da.costa@intel.com>