### PR TITLE
qatestcase.py: Don't search for device ip again

### DIFF
--- a/testing_harness/testcases/qatestcase.py
+++ b/testing_harness/testcases/qatestcase.py
@@ -26,11 +26,9 @@ class QATestCase(BasicTestCase):
     """
 
     def run(self, device):
-        ip_address = device.get_ip()
-
         # Append --target-ip parameter
         if not "--target-ip" in self.parameters:
-            self.parameters += " " + "--target-ip " + ip_address
+            self.parameters += " --target-ip " + device.dev_ip
 
         self.run_local_command()
         return self._result_has_zero_fails()


### PR DESCRIPTION
When device has been booted with the target image, it already has the ip
address in it's variables so no need to search for it again. This should
make using qatestcase.py more robust.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>