### PR TITLE
testing_harness: Free dnsmasq leases before and after --emulateusb

### DIFF
--- a/testing_harness/devicesmanager.py
+++ b/testing_harness/devicesmanager.py
@@ -340,6 +340,7 @@ class DevicesManager(object):
             print("Image file doesn't exist")
             raise errors.AFTImageNameError("Image file doesn't exist")
         local_execute(("start_libcomposite " + image_file).split())
+        logger.info("Started USB mass storage emulation using " + image_file)
 
     def stop_image_usb_emulation(self):
         """
@@ -348,6 +349,7 @@ class DevicesManager(object):
         self.free_dnsmasq_leases()
         local_execute("stop_libcomposite".split())
         local_execute("systemctl start libcomposite.service".split())
+        logger.info("Stopped USB mass storage emulation with an image")
 
     def free_dnsmasq_leases(self):
         """
@@ -360,6 +362,7 @@ class DevicesManager(object):
             f.write("")
             f.flush()
         local_execute("systemctl start dnsmasq.service".split())
+        logger.info("Freed dnsmasq leases")
 
     def boot_device_to_mode(self, device, mode, mode_name=""):
         '''

--- a/testing_harness/devicesmanager.py
+++ b/testing_harness/devicesmanager.py
@@ -334,15 +334,7 @@ class DevicesManager(object):
         """
         if self.check_libcomposite_service_running():
             local_execute("systemctl stop libcomposite.service".split())
-
-        # dnsmasq.leases file needs to be cleared and dnsmasq.service restarted
-        # or there will be no free IP address to give for DUT if different
-        # images are used in quick succession
-        local_execute("systemctl stop dnsmasq.service".split())
-        with open("/var/lib/misc/dnsmasq.leases", "w") as f:
-            f.write("")
-        local_execute("systemctl start dnsmasq.service".split())
-
+        self.free_dnsmasq_leases()
         image_file = os.path.abspath(args.file_name)
         if not os.path.isfile(image_file):
             print("Image file doesn't exist")
@@ -353,8 +345,21 @@ class DevicesManager(object):
         """
         Stop using the image with USB mass storage emulation
         """
+        self.free_dnsmasq_leases()
         local_execute("stop_libcomposite".split())
         local_execute("systemctl start libcomposite.service".split())
+
+    def free_dnsmasq_leases(self):
+        """
+        dnsmasq.leases file needs to be cleared and dnsmasq.service restarted
+        or there will be no IP address to give for DUT if same
+        image is used in quick succession with and without --emulateusb
+        """
+        local_execute("systemctl stop dnsmasq.service".split())
+        with open("/var/lib/misc/dnsmasq.leases", "w") as f:
+            f.write("")
+            f.flush()
+        local_execute("systemctl start dnsmasq.service".split())
 
     def boot_device_to_mode(self, device, mode, mode_name=""):
         '''


### PR DESCRIPTION
If --emulateusb argument is used with an image and then the same image
is flashed to internal memory, there will be no free IP address to give
until the previous lease expires. So free up dnsmasq leases before and
after using USB mass storage emulation with an image.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>