### PR TITLE
pc_host: FlashImageError not raising an error

### DIFF
--- a/pc_host/main.py
+++ b/pc_host/main.py
@@ -72,6 +72,7 @@ def main():
                     f.write("Blacklisted because flashing failed\n")
                     print("Flashing failed, blacklisted " +
                           beaglebone_dut["device"])
+        raise
 
     except:
         if beaglebone_dut:


### PR DESCRIPTION
Fix the FlashImageError to raise an error. Previously it simply returned 0 (as default).

Signed-off-by: Christian da Costa <christian.da.costa@intel.com>