### PR TITLE
testing_harness: Remove hard coded dnsmasq leases file

### DIFF
--- a/testing_harness/devices/pcdevice.py
+++ b/testing_harness/devices/pcdevice.py
@@ -72,7 +72,7 @@ class PCDevice(Device):
                                        channel=channel,
                                        kb_emulator=kb_emulator)
 
-        self._leases_file_name = parameters["leases_file_name"]
+        self.leases_file_name = parameters["leases_file_name"]
         self._service_mode_name = parameters["service_mode"]
         self._test_mode_name = parameters["test_mode"]
         self._test_mode = {

--- a/testing_harness/main.py
+++ b/testing_harness/main.py
@@ -67,7 +67,8 @@ def main(argv=None):
             if not args.nopoweroff:
                 device.detach()
                 if args.emulateusb:
-                    device_manager.stop_image_usb_emulation()
+                    device_manager.stop_image_usb_emulation(
+                                                    device.leases_file_name)
 
         if args.boot:
             device_manager.boot_device_to_mode(device, args.boot)


### PR DESCRIPTION
It should be taken from devices config files and not hard coded.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>