### PR TITLE
testing_harness: Remove --device parameter that isn't needed

### DIFF
--- a/testing_harness/devicesmanager.py
+++ b/testing_harness/devicesmanager.py
@@ -225,38 +225,6 @@ class DevicesManager(object):
             if os.path.isfile(path):
                 os.unlink(path)
 
-    def try_flash_specific(self, args):
-        '''
-        Reserve and flash specific device.
-
-        Args:
-            args: AFT arguments
-        Returns:
-            device, tester: Reserved machine and tester handles.
-        '''
-        device = self.reserve_specific(args.device, model=args.machine)
-        if args.testplan:
-            device.test_plan = args.testplan
-        tester = Tester(device)
-
-        if args.record:
-            device.record_serial()
-
-        if not self.check_libcomposite_service_running():
-            self.stop_image_usb_emulation(device.leases_file_name)
-
-        if args.emulateusb:
-            self.start_image_usb_emulation(args, device.leases_file_name)
-            inject_ssh_keys_to_image(args.file_name)
-            return device, tester
-
-        if not args.noflash:
-            print("Flashing " + str(device.name) + ".")
-            device.write_image(args.file_name)
-            print("Flashing successful.")
-
-        return device, tester
-
     def try_flash_model(self, args):
         '''
         Reserve and flash a machine. By default it tries to flash 2 times,

--- a/testing_harness/main.py
+++ b/testing_harness/main.py
@@ -47,11 +47,7 @@ def main(argv=None):
             logger.level(logging.DEBUG)
 
         device_manager = DevicesManager(args)
-
-        if args.device:
-            device, tester = device_manager.try_flash_specific(args)
-        else:
-            device, tester = device_manager.try_flash_model(args)
+        device, tester = device_manager.try_flash_model(args)
 
         if args.emulateusb:
             device.boot_usb_test_mode()
@@ -115,14 +111,6 @@ def parse_args():
         nargs="?",
         help = "Image to write: a local file, compatible with the selected " +
         "machine.")
-
-    parser.add_argument(
-        "--device",
-        type=str,
-        nargs="?",
-        action="store",
-        default="",
-        help="Specify the individual physical device by name.")
 
     parser.add_argument(
         "--flash_retries",


### PR DESCRIPTION
This feature isn't really working/needed on this setup and was copied
from the legacy AFT code.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>