### PR TITLE
initialize_testing_harness: Add gpio pin to script

### DIFF
--- a/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness
+++ b/testing_harness_image_extras/initialize_testing_harness/initialize_testing_harness
@@ -22,6 +22,10 @@ set_up_gpio() {
   echo 60 > /sys/class/gpio/export
   echo out > /sys/class/gpio/gpio60/direction
   echo 0 > /sys/class/gpio/gpio60/value
+
+  # These are for Refkit GPIO test
+  echo 20 > /sys/class/gpio/export
+  echo in > /sys/class/gpio/gpio20/direction
 }
 
 set_up_system() {


### PR DESCRIPTION
This pin is used for Refkit GPIO test.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>