### PR TITLE
testing_harness: Set beaglebones gpio20 values to default prior to testing

### DIFF
--- a/testing_harness/tester.py
+++ b/testing_harness/tester.py
@@ -18,6 +18,8 @@ Class implementing a Tester interface.
 
 import os
 import time
+import subprocess
+
 try:
     import ConfigParser
 except ImportError:
@@ -60,8 +62,14 @@ class Tester(object):
 
     def execute(self):
         """
-        Execute the test plan.
+        Set values to default and execute the test plan.
         """
+
+        #Set the Beaglebones gpio20 values to default
+        logger.info("Setting Beaglebone gpio testing pin back to default")
+        subprocess.call("echo 20 > /sys/class/gpio/export",shell=True)
+        subprocess.call("echo in > /sys/class/gpio/gpio20/direction", shell=True)
+
         logger.info("Executing the test plan")
         self._start_time = time.time()
         logger.info("Test plan start time: " + str(self._start_time))


### PR DESCRIPTION
Beaglebone runs a script called initialize_testing_harness each time it boots. This particular script sets some values such as GPIO pins  etc. to default. The problems is that, if a test changes these values, they are not be set back to default until the Beaglebone reboots and hence might fail other tests that are run after. This fix now makes the script run every time it starts a new test case.

Signed-off-by: Christian da Costa <christian.da.costa@intel.com>