### PR TITLE
README.MD: BBB NFS image creation manual boot settings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -949,14 +949,23 @@ sudo e2fsck -f /dev/<b>sdX1</b>
 sudo resize2fs /dev/<b>sdX1</b>
 </pre>
 
-Connect the USB stick to BBB and boot it. Use USB-serial cable or monitor and
+Connect the USB stick or SD card to BBB and boot it. Use USB-serial cable or monitor and
 keyboard and stop the U-Boot from doing default boot by pressing space. Use this
-command to boot from USB stick and change 4.4.9-ti-r25 to match your version number:
+command to boot from your storage device and change 4.4.9-ti-r25 to match your version number:
+
+<b>Boot settings for USB stick</b>
 <pre>
-setenv bootargs 'console=ttyO0,115200n8, root=/dev/sda1 rootwait rootfstype=ext4 rw'
+setenv bootargs 'console=ttyO0,115200n8, root=/dev/sda1 rootfstype=ext4 rw'
 usb start
 ext4load usb 0:1 0x81000000 /boot/vmlinuz-<b>4.4.9-ti-r25</b>
 ext4load usb 0:1 0x80000000 /boot/dtbs/<b>4.4.9-ti-r25</b>/am335x-boneblack.dtb; bootz 0x81000000 - 0x80000000
+</pre>
+
+<b>Boot settings for SD card</b>
+<pre>
+setenv bootargs 'console=ttyO0,115200n8, root=/dev/mmcblk1p1 rootfstype=ext4 rw'
+ext4load mmc 0:1 0x81000000 /boot/vmlinuz-<b>4.4.9-ti-r25</b>
+ext4load mmc 0:1 0x80000000 /boot/dtbs/<b>4.4.9-ti-r25</b>/am335x-boneblack.dtb; bootz 0x81000000 - 0x80000000
 </pre>
 
 When BBB has booted do all of these commands to make all the changes needed for


### PR DESCRIPTION
Removed rootwait as the boot can get stuck waiting forever if a device such as /dev/sda1 or /dev/mmcblk1p1 is not found. Rootwait is better reserved for booting from NFS as there may be a delay.

Added instructions for SD card manual boot as the settings differ from USB stick manual boot settings.

Signed-off-by: Sami Nieminen <sami1.nieminen@intel.com>