### PR TITLE
README.MD: Remove root_partition options from readme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -603,7 +603,6 @@ sudo vim /daft/bbb_fs/etc/aft/devices/catalog.cfg
 platform = PC
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
-root_partition = /dev/mmcblk0p3
 service_mode = Ubuntu
 boot_usb_keystrokes = <b>/root/kbsequences/joule/boot_usb</b>
 boot_internal_keystrokes = <b>/root/kbsequences/empty</b>
@@ -614,7 +613,6 @@ platform = PC
 serial_port = /dev/ttyUSB0
 test_plan = iot_qatest
 target_device = /dev/mmcblk0
-root_partition = /dev/mmcblk0p3
 service_mode = Ubuntu
 boot_usb_keystrokes = <b>/root/kbsequences/minnowboard/boot_usb</b>
 boot_internal_keystrokes = <b>/root/kbsequences/empty</b>


### PR DESCRIPTION
Remove root_partition option from the DAFT readme, because it hasn't been used for a long time and doesn't exist anymore.

Signed-off-by: Christian da Costa <christian.da.costa@intel.com>